### PR TITLE
Fix a bug in the string slice operations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-07-16  Kirit Sælensminde  <kirit@felspar.com>
+ Fix a bug in the string slice operations that could cause undefined behaviour when used with `nullptr` buffers.
+
 2019-03-01  Kirit Sælensminde  <kirit@felspar.com>
  Deprecated two argument `substr` as the second argument handling doesn't match `std::string::substr`.
 

--- a/include/f5/memory.hpp
+++ b/include/f5/memory.hpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2017-2018, Felspar Co Ltd. <http://www.kirit.com/f5>
+    Copyright 2017-2019, Felspar Co Ltd. <http://www.kirit.com/f5>
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -95,12 +95,24 @@ namespace f5 {
         /// Return true if there are no items in the array
         constexpr bool empty() const noexcept { return m_size == 0; }
 
-        /// Return a slice of this array
+        /// Return a slice of this array.
+        /**
+         * These operations are safe over the buffer, meaning that if too
+         * much is requested then the slice returned will be the subset
+         * covered by the requested slice and the pre-existing buffer.
+         *
+         * It is safe to ask for a start position beyond the start of the buffer,
+         * or to ask for more data than is in the buffer. An appropriate
+         * (possibly empty) buffer will be returned.
+         */
         constexpr buffer slice(std::size_t start) const {
-            return buffer(m_data + start, m_size - start);
+            auto const actual = std::min(start, m_size);
+            return buffer{m_data + actual, m_size - actual};
         }
         constexpr buffer slice(std::size_t start, std::size_t items) const {
-            return buffer(m_data + start, items);
+            auto const actual = std::min(start, m_size);
+            auto const length = std::min(items, m_size - actual);
+            return buffer(m_data + actual, length);
         }
 
         /// Ordering. Performs element-wise ordering. In a tie the shortest
@@ -170,6 +182,8 @@ namespace f5 {
                 std::shared_ptr<V> ptr, std::size_t begin, std::size_t count)
         : m_data(std::move(ptr), ptr.get() + begin), m_size(count) {}
 
+        friend shared_buffer<std::add_const_t<V>>;
+
       public:
         /// Buffer types
         using buffer_type = buffer<std::remove_const_t<V>>;
@@ -195,8 +209,18 @@ namespace f5 {
         /// an array of contiguous memory that can be sliced.
         shared_buffer(std::shared_ptr<V> p, std::size_t s)
         : m_data{s ? p : std::shared_ptr<V>{}}, m_size{s} {}
-        shared_buffer(shared_buffer op, pointer_const_type p, std::size_t s)
+        shared_buffer(shared_buffer op, std::add_pointer_t<V> p, std::size_t s)
         : m_data(op.m_data, p), m_size(s) {}
+
+        /// Conversion from non-`const` buffer to `const` buffer
+        /**
+         * The friendship required for this constructor is only defined
+         * for the `const` version of the non-`const`. So if `Y` is the
+         * non-`const` version of `V` then this will work.
+         */
+        template<typename Y>
+        shared_buffer(shared_buffer<Y> b)
+        : m_data{b.m_data}, m_size{b.m_size} {}
 
         /// The number of elements in the buffer
         std::size_t size() const noexcept { return m_size; }
@@ -209,11 +233,17 @@ namespace f5 {
         V &operator[](std::size_t index) { return data()[index]; }
 
         /// Return a slice which is also shared
+        /**
+         * These are implemented on top of the non-shared buffer type
+         * so share its safety of out-of-bounds requests.
+         */
         shared_buffer slice(std::size_t index) const {
-            return shared_buffer(m_data, index, m_size - index);
+            auto s = buffer<V>{m_data.get(), m_size}.slice(index);
+            return shared_buffer{*this, s.data(), s.size()};
         }
         shared_buffer slice(std::size_t index, std::size_t count) const {
-            return shared_buffer(m_data, index, count);
+            auto s = buffer<V>{m_data.get(), m_size}.slice(index, count);
+            return shared_buffer{*this, s.data(), s.size()};
         }
 
         /// Iteration across the memory

--- a/test/compile/memory.cpp
+++ b/test/compile/memory.cpp
@@ -7,3 +7,8 @@ constexpr auto bc = abc.slice(1);
 static_assert(bc[0] == 'b', "Expected b");
 static_assert(bc[1] == 'c', "Expected c");
 static_assert(bc.size() == 2, "Expected 2 letters");
+
+static_assert(abc.slice(1).data() == bc.data(), "Expected same result");
+static_assert(abc.slice(100).size() == 0u, "Expected empty buffer");
+static_assert(abc.slice(1, 100).size() == 2u, "Expected limited buffer");
+static_assert(abc.slice(100, 100).size() == 0u, "Expected empty buffer");

--- a/test/run/memory.cpp
+++ b/test/run/memory.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2016-2018, Felspar Co Ltd. <https://kirit.com/f5>
+    Copyright 2016-2019, Felspar Co Ltd. <https://kirit.com/f5>
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -12,10 +12,8 @@
 #include <f5/memory.hpp>
 
 
-int main() {
-    int items[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    f5::shared_buffer<int> b1{10};
-    std::copy(std::begin(items), std::end(items), b1.begin());
+template<typename T>
+void tests(f5::shared_buffer<T> b1) {
     assert(b1[0] == 0);
     assert(b1[8] == 8);
 
@@ -29,15 +27,32 @@ int main() {
     assert(b3[1] == 3);
     assert(b3[2] == 4);
 
-    f5::buffer<int> b4 = b1;
+    /// These are all safe operations
+    assert(b1.slice(100).size() == 0u);
+    assert(b1.slice(1, 100).size() == 9u);
+    assert(b1.slice(100, 100).size() == 0u);
+
+    f5::buffer<T> b4 = b1;
     assert(b4.size() == 10);
-    f5::buffer<const int> b5 = b3;
+    f5::buffer<const T> b5 = b3;
     assert(b5.size() == 3);
-    f5::buffer<int> b6 = b1.slice(6);
+    f5::buffer<T> b6 = b1.slice(6);
     assert(b6.size() == 4);
 
-    f5::buffer<const int> b7 = b1;
+    f5::buffer<const T> b7 = b1;
     assert(b7.size() == 10);
+}
+
+
+int main() {
+    int const items[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    f5::shared_buffer<int> buf{10};
+    std::copy(std::begin(items), std::end(items), buf.begin());
+    tests(buf);
+
+    f5::shared_buffer<int const> cbuf{buf};
+    tests(cbuf);
 
     return 0;
 }


### PR DESCRIPTION
Under some circumstances the bug here could cause undefined behaviour. Basically the string slice operations assumed that the underlying buffer slices would always be safe, but the buffer slice operations assumed that the parameters were always valid. The mismatch could cause problems, especially if the buffer pointer was `nullptr`.