### PR TITLE
We can't force -Werror on all builds.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_compile_options(
         -fdiagnostics-show-option
-        -Werror -Wall -Wextra -Wpedantic
+        -Wall -Wextra -Wpedantic
         -Wno-gnu-string-literal-operator-template
         -Wno-unused-const-variable
         -Wno-unused-local-typedefs


### PR DESCRIPTION
Forcing this option causes problems with new compilers as builds fail instead of just issuing new warnings.

We don't want to turn problems into emergencies.