### PR TITLE
Use members for (in)equality checks so that we can reliably detect them.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2020-04-08  Kirit Sælensminde  <kirit@felspar.com>
+ Refactor the way equality and inequality members work to cut down on code duplication.
+
 2020-01-29  Kirit Sælensminde  <kirit@felspar.com>
  `f5::cord::basic_string` instances can now be created using character literals of other Unicode encodings.
 

--- a/include/f5/cord/unicode-string.hpp
+++ b/include/f5/cord/unicode-string.hpp
@@ -90,6 +90,9 @@ namespace f5 {
                 buffer = buffer_type{
                         created.second->data(), created.second->size()};
             }
+            /// Given a data block we are going to have to allocate as well
+            basic_string(value_type const *data, std::size_t size)
+            : basic_string(std_string{data, size}) {}
 
             /// Construct from character literals in the non-native encodings
             template<typename O, std::size_t N>

--- a/include/f5/cord/unicode-string.hpp
+++ b/include/f5/cord/unicode-string.hpp
@@ -65,7 +65,9 @@ namespace f5 {
             : buffer{b.buffer}, owner{std::exchange(b.owner, nullptr)} {}
 
             /// Creation from a `basic_view` will never allocate because the
-            /// `basic_view` remembers the shared status of its history
+            /// `basic_view` remembers the shared status of its history.
+            /// During the transitional period however basic_view *may*
+            /// allocate.
             basic_string(view_type const v)
             : buffer{buffer_type{v}},
               owner{control_type::increment(v.control_block())} {
@@ -252,14 +254,14 @@ namespace f5 {
                 return view_type{l} == view_type{r};
             }
             template<typename O>
-            friend std::enable_if_t<is_detected_v<op_eq_t, view_type, O>, bool>
+            friend std::enable_if_t<is_detected_v<op_meq_t, view_type, O>, bool>
                     operator==(basic_string const &s, O const &l) {
                 return view_type{s} == l;
             }
             template<typename O>
-            friend std::enable_if_t<is_detected_v<op_eq_t, O, view_type>, bool>
+            friend std::enable_if_t<is_detected_v<op_meq_t, view_type, O>, bool>
                     operator==(O const &r, basic_string const &s) {
-                return r == view_type{s};
+                return view_type{s} == r;
             }
 
             friend bool
@@ -267,14 +269,14 @@ namespace f5 {
                 return view_type{l} != view_type{r};
             }
             template<typename O>
-            friend std::enable_if_t<is_detected_v<op_eq_t, view_type, O>, bool>
+            friend std::enable_if_t<is_detected_v<op_meq_t, view_type, O>, bool>
                     operator!=(basic_string const &s, O const &l) {
                 return view_type{s} != l;
             }
             template<typename O>
-            friend std::enable_if_t<is_detected_v<op_eq_t, O, view_type>, bool>
+            friend std::enable_if_t<is_detected_v<op_meq_t, view_type, O>, bool>
                     operator!=(O const &r, basic_string const &s) {
-                return r != view_type{s};
+                return view_type{s} != r;
             }
 
             bool operator<(view_type l) const { return view_type{buffer} < l; }

--- a/include/f5/cord/unicode-view.hpp
+++ b/include/f5/cord/unicode-view.hpp
@@ -205,8 +205,7 @@ namespace f5 {
             /// Comparison. Acts as a string would. Not Unicode aware in
             /// that it doesn't take into account normalisation, it only
             /// compares the byte values.
-            constexpr bool
-                    operator==(basic_view r) const noexcept {
+            constexpr bool operator==(basic_view r) const noexcept {
                 if (buffer.size() == r.buffer.size()) {
                     if (buffer.data() != r.buffer.data()) {
                         for (std::size_t s{}; s != buffer.size(); ++s) {

--- a/include/f5/cord/unicode-view.hpp
+++ b/include/f5/cord/unicode-view.hpp
@@ -313,7 +313,7 @@ namespace f5 {
         }
 
         /// Equality against other types
-        inline bool operator==(lstring l, u8view r) { return r == l; }
+        inline bool operator==(lstring l, u8view r) { return r == u8view{l}; }
 
         /// Comparison against other types
         inline bool operator<(lstring l, u8view r) { return u8view(l) < r; }

--- a/include/f5/detect.hpp
+++ b/include/f5/detect.hpp
@@ -55,8 +55,10 @@ namespace f5 {
 
 
     template<typename L, typename R>
-    using op_eq_t =
-            decltype(std::declval<L const &>() == std::declval<R const &>());
+    using op_eq_t = decltype(std::declval<L>() == std::declval<R>());
+
+    template<typename L, typename R>
+    using op_meq_t = decltype(std::declval<L>().operator==(std::declval<R>()));
 
 
 }


### PR DESCRIPTION
This minor change helps us to detect the equality operators are properly available when needed so they can be re-used.